### PR TITLE
Fix lvl_is_XXX

### DIFF
--- a/configure
+++ b/configure
@@ -2997,13 +2997,13 @@ if test "$ac_test_CFLAGS" = set; then
   CFLAGS=$ac_save_CFLAGS
 elif test $ac_cv_prog_cc_g = yes; then
   if test "$GCC" = yes; then
-    CFLAGS="-g -O2"
+    CFLAGS="-g -O3"
   else
     CFLAGS="-g"
   fi
 else
   if test "$GCC" = yes; then
-    CFLAGS="-O2"
+    CFLAGS="-O3"
   else
     CFLAGS=
   fi
@@ -4149,7 +4149,7 @@ case "$target_os" in
                 LDFLAGS="$LDFLAGS -Wl,-elf2flt"
         ;;
 	darwin*)
-		CFLAGS="$CFLAGS -no-cpp-precomp"
+		CFLAGS="$CFLAGS -fpic -no-cpp-precomp"
 	;;
   wasi)
     CFLAGS="$CFLAGS -DDIE_ON_ERROR -DCST_NO_SOCKETS -DWASM32_WASI"

--- a/lang/lvl_is_lang/lvl_is_phoneset.c
+++ b/lang/lvl_is_lang/lvl_is_phoneset.c
@@ -281,7 +281,7 @@ const cst_phoneset lvl_is_phoneset = {
   lvl_is_featvals,
   lvl_is_phonenames,
   "pau",
-  59,
+  60,
   lvl_is_fvtable,
   0  /* not freeable */
 };

--- a/lang/lvl_is_lex/lvl_is_lex.c
+++ b/lang/lvl_is_lex/lvl_is_lex.c
@@ -107,7 +107,7 @@ static int lvl_is_sonority(const char *p)
 {
     if (lvl_is_is_vowel(p) || (lvl_is_is_silence(p)))
 	return 5;
-    else if ((sizeof(p) < 2 || strchr("0",p[2]) == NULL) && strchr("wylr",p[0]) != NULL)
+    else if ((cst_strlen(p) < 2 || strchr("0",p[2]) == NULL) && strchr("wylr",p[0]) != NULL)
 	return 4;  /* glides/liquids */
     else if (strchr("nmNJ",p[0]) != NULL)
 	return 3;  /* nasals */


### PR DESCRIPTION
- `lvl_is_phoneset.c`: fix table size, otherwise symbol `pau` is not included
- `lvl_is_lex.c`: use `cst_strlen()` instead of `sizeof()` for passed C-string
- `configure`: adaptions for mac os x build for local testing 

